### PR TITLE
mLJR 0.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Download zip file
 
 #### Installation
 ```
+pip install mljr
+
+Or
+
 python[3] setup.py install
 ```
 

--- a/mljr/mljr.py
+++ b/mljr/mljr.py
@@ -4,7 +4,7 @@ import os
 import math
 import argparse
 
-__version__ = 0.50
+__version__ = 0.51
 
 # Modified Lydersen-Joback-Reid method
 #

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,33 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 
+import os
 from setuptools import setup
 import mljr
 from mljr.mljr import __version__
 
 
+def read(*names):
+    values = {}
+    extensions = ['', '.txt', '.rst', '.md',]
+    for name in names:
+        v = ''
+        for ext in extensions:
+            filename = name + ext
+            if os.path.isfile(filename):
+                with open(filename) as f:
+                    v = f.read()
+        values[name] = v
+    return values
+
+long_description = """%(README)s""" % read('README')
+
 setup(
     name='mljr',
     version=__version__,
     description='Modified Lydersen-Joback-Reid method',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     classifiers=[
         "Programming Language :: Python :: 3",
         "Environment :: Console",


### PR DESCRIPTION
This version is released to Python Package Index (official website)

PYPI link: [https://pypi.org/project/mljr/](https://pypi.org/project/mljr/)